### PR TITLE
Add conversation logging

### DIFF
--- a/src/handlers/llm/openai_compatible/chat_history_manager.py
+++ b/src/handlers/llm/openai_compatible/chat_history_manager.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import os
 import re
 from typing import Literal, Optional
 
@@ -26,9 +27,13 @@ def filter_text(text):
 
 
 class ChatHistory:
-    def __init__(self):
+    def __init__(self, session_id: Optional[str] = None, log_dir: str = "logs"):
         self.max_history_length = 20
         self.message_history = []
+        self.log_file = None
+        if session_id is not None:
+            os.makedirs(log_dir, exist_ok=True)
+            self.log_file = os.path.join(log_dir, f"{session_id}.txt")
 
     def add_message(self, message: HistoryMessage):
         history = self.message_history
@@ -36,6 +41,10 @@ class ChatHistory:
         # thread safe
         while len(history) >= self.max_history_length:
             history.pop(0)
+        if self.log_file:
+            role = message.role or "unknown"
+            with open(self.log_file, "a", encoding="utf-8") as f:
+                f.write(f"{role}: {message.content}\n")
 
     def generate_next_messages(self, chat_text, images):
         def history_to_message(history: HistoryMessage):

--- a/src/handlers/llm/openai_compatible/llm_handler_openai_compatible.py
+++ b/src/handlers/llm/openai_compatible/llm_handler_openai_compatible.py
@@ -38,7 +38,7 @@ class LLMContext(HandlerContext):
         self.input_texts = ""
         self.output_texts = ""
         self.current_image = None
-        self.history = ChatHistory()
+        self.history = ChatHistory(session_id)
         self.enable_video_input = False
 
 

--- a/tests/unittest/test_chat_history_logging.py
+++ b/tests/unittest/test_chat_history_logging.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+import tempfile
+from handlers.llm.openai_compatible.chat_history_manager import ChatHistory, HistoryMessage
+
+
+class TestChatHistoryLogging(unittest.TestCase):
+    def test_logging_to_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            history = ChatHistory(session_id="test", log_dir=tmpdir)
+            history.add_message(HistoryMessage(role="human", content="hello"))
+            history.add_message(HistoryMessage(role="avatar", content="hi"))
+
+            log_path = os.path.join(tmpdir, "test.txt")
+            with open(log_path, "r", encoding="utf-8") as f:
+                lines = f.read().splitlines()
+
+            self.assertEqual(lines, ["human: hello", "avatar: hi"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- log ChatHistory messages to per-session files under `logs`
- initialize ChatHistory with session id for log file creation
- add unit test for logging behaviour

## Testing
- `python -m unittest discover -s tests/unittest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d054aa2148323a441ccfa33c3612a