### PR TITLE
Add date prefix to chat log files

### DIFF
--- a/src/handlers/llm/openai_compatible/chat_history_manager.py
+++ b/src/handlers/llm/openai_compatible/chat_history_manager.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import os
 import re
+from datetime import datetime
 from typing import Literal, Optional
 
 
@@ -33,7 +34,8 @@ class ChatHistory:
         self.log_file = None
         if session_id is not None:
             os.makedirs(log_dir, exist_ok=True)
-            self.log_file = os.path.join(log_dir, f"{session_id}.txt")
+            date_prefix = datetime.now().strftime("%Y%m%d-")
+            self.log_file = os.path.join(log_dir, f"{date_prefix}{session_id}.txt")
 
     def add_message(self, message: HistoryMessage):
         history = self.message_history

--- a/tests/unittest/test_chat_history_logging.py
+++ b/tests/unittest/test_chat_history_logging.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import tempfile
+from datetime import datetime
 from handlers.llm.openai_compatible.chat_history_manager import ChatHistory, HistoryMessage
 
 
@@ -11,7 +12,8 @@ class TestChatHistoryLogging(unittest.TestCase):
             history.add_message(HistoryMessage(role="human", content="hello"))
             history.add_message(HistoryMessage(role="avatar", content="hi"))
 
-            log_path = os.path.join(tmpdir, "test.txt")
+            prefix = datetime.now().strftime("%Y%m%d-")
+            log_path = os.path.join(tmpdir, f"{prefix}test.txt")
             with open(log_path, "r", encoding="utf-8") as f:
                 lines = f.read().splitlines()
 


### PR DESCRIPTION
## Summary
- add `datetime` to generate log filename prefix
- include `yyyyMMdd-` date prefix in ChatHistory log file name
- update chat history logging test

## Testing
- `PYTHONPATH=src pytest tests/unittest/test_chat_history_logging.py::TestChatHistoryLogging::test_logging_to_file -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68760a66f77083239e044cf360baf904